### PR TITLE
Align Model terminology with multiple digital credential ecosystems.

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,11 @@
       Model
     </h2>
 
-    <p class="issue" title="Definitions under discussion">
-The goal of the definitions in this section is to re-use or establish
+    <p class="note" title="Definitions under discussion">
+The goal of the definitions in this section is to reuse or establish
 terminology that is common across a variety of digital credential formats and
-protocols.
+protocols. Discussions surrounding these definitions are active and
+the definitions are likely to change over the next several months.
     </p>
 
     <dl class="definitions" data-sort="" data-cite="vc-data-model-2.0">

--- a/index.html
+++ b/index.html
@@ -107,8 +107,7 @@ protocols.
         Software that provides a user interface for querying, selecting, and
         establishing consent for the [=presentation=] of a [=digital
         credential=]. Examples include a digital wallet, or a login manager,
-        that manages various
-        <a href="#credential-type-examples">credential types</a>.
+        that manages various [=example credential types|credential types=].
       </dd>
       <dt>
         <dfn>Presentation request</dfn>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@ protocols.
         <dfn>Presentation request</dfn>
       </dt>
       <dd>
-        A format that a [=verifier=] uses, via an [=exchange protocol=] to
+        A format that a [=verifier=] uses, via an [=exchange protocol=], to
         request a [=digital credential=] from a [=credential provider=].
       </dd>
       <dt>
@@ -122,7 +122,7 @@ protocols.
       </dt>
       <dd>
         A format that a [=credential repository=] uses, via an
-        [=exchange protocol=] to respond to a [=presentation request=] by
+        [=exchange protocol=], to respond to a [=presentation request=] by
         a [=verifier=].
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@ protocols.
         a [=verifier=].
       </dd>
       <dt>
-        <dfn>Exchange protocol</dfn>
+        <dfn data-dfn-for="digital credential">Exchange protocol</dfn>
       </dt>
       <dd>
         A protocol used for exchanging a [=digital credential=] between a

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ the definitions are likely to change over the next several months.
         protocol=], to request a [=digital credential=] from a [=holder=].
       </dd>
       <dt>
-        <dfn>Presentation</dfn>
+        <dfn>Presentation response</dfn>
       </dt>
       <dd>
         A format that a [=holder=] uses, via an [=digital

--- a/index.html
+++ b/index.html
@@ -31,15 +31,7 @@
       shortName: "digital-identity",
       specStatus: "CG-DRAFT",
       group: "wicg",
-      localBiblio: {
-        "ISO18013-5": {
-          title: "ISO/IEC 18013-5:2021 ISO-compliant driving licence, Part 5: Mobile driving licence (mDL) application",
-          authors: ["ISO/IEC JTC 1/SC 17"],
-          date: "September 2021",
-          publisher: "International Organization for Standardization",
-          href: "https://www.iso.org/standard/69084.html"
-        }
-      },
+      localBiblio: {},
       xref: {
         profile: "web-platform",
       },

--- a/index.html
+++ b/index.html
@@ -101,19 +101,20 @@ the definitions are likely to change over the next several months.
         that manages various [=example credential types|credential types=].
       </dd>
       <dt>
-        <dfn>Presentation request</dfn>
+        <dfn data-dfn-for="digital credential">query</dfn>
       </dt>
       <dd>
-        A format that a [=verifier=] uses, via an [=exchange protocol=], to
-        request a [=digital credential=] from a [=credential provider=].
+        A format that a [=verifier=] uses, via an [=digital credential/exchange
+        protocol=], to request a [=digital credential=] from a [=credential
+        provider=].
       </dd>
       <dt>
         <dfn>Presentation</dfn>
       </dt>
       <dd>
-        A format that a [=credential repository=] uses, via an
-        [=exchange protocol=], to respond to a [=presentation request=] by
-        a [=verifier=].
+        A format that a [=credential repository=] uses, via an [=digital
+        credential/exchange protocol=], to respond to a [=digital
+        credential/query=] by a [=verifier=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential">Exchange protocol</dfn>
@@ -193,16 +194,17 @@ the definitions are likely to change over the next several months.
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
-      specify an [=exchange protocol=] and [=presentation request=],
-      which the user agent MAY match against a [=credential provider=].
+      specify an [=digital credential/exchange protocol=] and [=digital
+      credential/query=], which the user agent MAY match against a [=credential
+      provider=].
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
     </h2>
     <p>
-      The {{IdentityRequestProvider}} dictionary is used to specify an
-      [=exchange protocol=] and a [=presentation request=], which the user agent
-      MAY match against a [=credential provider=].
+      The {{IdentityRequestProvider}} dictionary is used to specify an [=digital
+      credential/exchange protocol=] and a [=digital credential/query=], which
+      the user agent MAY match against a [=credential provider=].
     </p>
     <pre class="idl">
     dictionary IdentityRequestProvider {
@@ -215,7 +217,7 @@ the definitions are likely to change over the next several months.
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">protocol</dfn> member
-      denotes the [=exchange protocol=] when requesting an
+      denotes the [=digital credential/exchange protocol=] when requesting an
       identify credential.
     </p>
     <p>
@@ -250,7 +252,7 @@ the definitions are likely to change over the next several months.
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
-      [=exchange protocol=] that was used to request the
+      [=digital credential/exchange protocol=] that was used to request the
       [=digital credential=].
     </p>
     <h3>
@@ -264,7 +266,7 @@ the definitions are likely to change over the next several months.
       Registry of protocols for requesting digital credential
     </h2>
     <p>
-      The following is the registry of [=exchange protocols=]
+      The following is the registry of [=digital credential/exchange protocols=]
       that are supported by this specification.
     </p>
     <p class="note" title="Official Registry" data-cite="w3c-process">
@@ -279,11 +281,13 @@ the definitions are likely to change over the next several months.
     </p>
     <aside class="issue" data-number="58"></aside>
     <p>
-      [=User agents=] MUST support the following [=exchange protocols=]:
+      [=User agents=] MUST support the following [=digital credential/exchange
+      protocols=]:
     </p>
     <table class="data">
       <caption>
-        Table of officially registered [=exchange protocols=].
+        Table of officially registered [=digital credential/exchange
+        protocols=].
       </caption>
       <thead>
         <tr>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ the definitions are likely to change over the next several months.
         [=claims=] made by an [=issuer=] about one or more [=subjects=].
       </dd>
       <dt>
-        <dfn>Credential provider</dfn>
+        <dfn>Credential manager</dfn>
       </dt>
       <dd>
         Software that provides a user interface for querying, selecting, and
@@ -106,13 +106,13 @@ the definitions are likely to change over the next several months.
       <dd>
         A format that a [=verifier=] uses, via an [=digital credential/exchange
         protocol=], to request a [=digital credential=] from a [=credential
-        provider=].
+        manager=].
       </dd>
       <dt>
         <dfn>Presentation</dfn>
       </dt>
       <dd>
-        A format that a [=credential repository=] uses, via an [=digital
+        A format that a [=credential manager=] uses, via an [=digital
         credential/exchange protocol=], to respond to a [=digital
         credential/query=] by a [=verifier=].
       </dd>
@@ -121,7 +121,7 @@ the definitions are likely to change over the next several months.
       </dt>
       <dd>
         A protocol used for exchanging a [=digital credential=] between a
-        [=credential provider=] and a [=verifier=]. See section
+        [=credential manager=] and a [=verifier=]. See section
         [[[#protocol-registry]]].
       </dd>
     </dl>
@@ -186,17 +186,17 @@ the definitions are likely to change over the next several months.
     </h2>
     <pre class="idl">
     dictionary DigitalCredentialRequestOptions {
-      sequence&lt;IdentityRequestProvider&gt; providers;
+      sequence&lt;IdentityRequestProvider&gt; managers;
     };
     </pre>
     <h3>
-      The `providers` member
+      The `managers` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
+      The <dfn data-dfn-for="DigitalCredentialRequestOptions">managers</dfn>
       specify an [=digital credential/exchange protocol=] and [=digital
       credential/query=], which the user agent MAY match against a [=credential
-      provider=].
+      manager=].
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
@@ -204,7 +204,7 @@ the definitions are likely to change over the next several months.
     <p>
       The {{IdentityRequestProvider}} dictionary is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/query=], which
-      the user agent MAY match against a [=credential provider=].
+      the user agent MAY match against a [=credential manager=].
     </p>
     <pre class="idl">
     dictionary IdentityRequestProvider {
@@ -231,7 +231,7 @@ the definitions are likely to change over the next several months.
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
       the request to be handled by the user's selected [=credential
-      provider=].
+      manager=].
     </p>
     <h2>
       The `DigitalCredential` interface

--- a/index.html
+++ b/index.html
@@ -107,9 +107,9 @@ the definitions are likely to change over the next several months.
         <dfn>Presentation response</dfn>
       </dt>
       <dd>
-        A format that a [=holder=] uses, via an [=digital
-        credential/exchange protocol=], to respond to a [=digital
-        credential/query=] by a [=verifier=].
+        A format that a [=holder|holder's=] software, such as a digital wallet,
+        uses, via an [=digital credential/exchange protocol=], to respond to a
+        [=digital credential/query=] by a [=verifier=].
       </dd>
       <dt>
         <dfn data-dfn-for="digital credential">Exchange protocol</dfn>

--- a/index.html
+++ b/index.html
@@ -90,6 +90,11 @@ the definitions are likely to change over the next several months.
       <dd>
         A cryptographically signed digital document containing one or more
         [=claims=] made by an [=issuer=] about one or more [=subjects=].
+
+        <p class="note" title="Focus on digital credentials about people">
+          This specification is focused on digital credentials pertaining to
+          people.
+        </p>
       </dd>
       <dt>
         <dfn>Credential manager</dfn>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ the definitions are likely to change over the next several months.
         <dfn>Digital credential</dfn>
       </dt>
       <dd>
-        A cryptographically secured digital document containing one or more
+        A cryptographically signed digital document containing one or more
         [=claims=] made by an [=issuer=] about one or more [=subjects=]. Examples include
         ISO mobile driver's licenses [[ISO18013-5]] and W3C [=verifiable
         credentials=] [[VC-DATA-MODEL-2.0]].

--- a/index.html
+++ b/index.html
@@ -32,6 +32,13 @@
       specStatus: "CG-DRAFT",
       group: "wicg",
       localBiblio: {
+        "ISO18013-5": {
+          title: "ISO/IEC 18013-5:2021 ISO-compliant driving licence, Part 5: Mobile driving licence (mDL) application",
+          authors: ["ISO/IEC JTC 1/SC 17"],
+          date: "September 2021",
+          publisher: "International Organization for Standardization",
+          href: "https://www.iso.org/standard/69084.html"
+        }
       },
       xref: {
         profile: "web-platform",
@@ -76,30 +83,55 @@
     <h2>
       Model
     </h2>
-    <dl class="definitions" data-sort="" data-cite="vc-data-model">
+
+    <p class="issue" title="Definitions under discussion">
+The goal of the definitions in this section is to re-use or establish
+terminology that is common across a variety of digital credential formats and
+protocols.
+    </p>
+
+    <dl class="definitions" data-sort="" data-cite="vc-data-model-2.0">
       <dt>
         <dfn>Digital credential</dfn>
       </dt>
       <dd>
-        <p>
-          Is a [=verifiable credential=] about a person.
-        </p>
+        A cryptographically secured digital document containing one or more
+        [=claims=] made by an [=issuer=] about a [=subject=]. Examples include
+        ISO mobile driver's licenses [[ISO18013-5]] and W3C [=verifiable
+        credentials=] [[VC-DATA-MODEL-2.0]].
       </dd>
       <dt>
-        <dfn>Identity credential provider</dfn>
+        <dfn>Credential provider</dfn>
       </dt>
       <dd>
-        An application or service that provides a user interface for selecting
-        and/or querying a [=digital credential=], such as a digital wallet that
-        manages various identity documents and credentials.
+        Software that provides a user interface for querying, selecting, and
+        establishing consent for the [=presentation=] of a [=digital
+        credential=]. Examples include a digital wallet, or a password manager,
+        that manages various
+        <a href="#credential-type-examples">credential types</a>.
       </dd>
       <dt>
-        <dfn data-for="digital credential">Request protocol</dfn>
+        <dfn>Presentation request</dfn>
       </dt>
       <dd>
-        A standardized format for requesting a [=digital credential=], designed
-        to ensure the secure, private, and interoperable exchange of identity
-        information. See section [[[#protocol-registry]]].
+        A format that a [=verifier=] uses, via an [=exchange protocol=] to
+        request a [=digital credential=] from a [=credential provider=].
+      </dd>
+      <dt>
+        <dfn>Presentation</dfn>
+      </dt>
+      <dd>
+        A format that a [=credential repository=] uses, via an
+        [=exchange protocol=] to respond to a [=presentation request=] by
+        a [=verifier=].
+      </dd>
+      <dt>
+        <dfn>Exchange protocol</dfn>
+      </dt>
+      <dd>
+        A protocol used for exchanging a [=digital credential=] between a
+        [=credential provider=] and a [=verifier=]. See section
+        [[[#protocol-registry]]].
       </dd>
     </dl>
     <h2>
@@ -171,17 +203,16 @@
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
-      specify a [=digital identity/request protocol=] and structured request,
-      which the user agent MAY match against a [=identity credential
-      provider=].
+      specify an [=exchange protocol=] and [=presentation request=],
+      which the user agent MAY match against a [=credential provider=].
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
     </h2>
     <p>
-      The {{IdentityRequestProvider}} dictionary is used to specify a [=digital
-      identity/request protocol=] and structured request, which the user agent
-      MAY match against a [=identity credential provider=].
+      The {{IdentityRequestProvider}} dictionary is used to specify an
+      [=exchange protocol=] and [=presentation request=], which the user agent
+      MAY match against a [=credential provider=].
     </p>
     <pre class="idl">
     dictionary IdentityRequestProvider {
@@ -194,7 +225,7 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">protocol</dfn> member
-      denotes the [=digital credential/request protocol=] when requesting an
+      denotes the [=exchange protocol=] when requesting an
       identify credential.
     </p>
     <p>
@@ -207,7 +238,7 @@
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
-      the request to be handled by the user's selected [=identity credential
+      the request to be handled by the user's selected [=credential
       provider=].
     </p>
     <h2>
@@ -229,7 +260,7 @@
     </h3>
     <p>
       The <dfn data-dfn-for="DigitalCredential">protocol</dfn> member is the
-      [=digital credential/request protocol=] that was used to request the
+      [=exchange protocol=] that was used to request the
       [=digital credential=].
     </p>
     <h3>
@@ -243,7 +274,7 @@
       Registry of protocols for requesting digital credential
     </h2>
     <p>
-      The following is the registry of [=digital credential/request protocols=]
+      The following is the registry of [=exchange protocols=]
       that are supported by this specification.
     </p>
     <p class="note" title="Official Registry" data-cite="w3c-process">
@@ -258,13 +289,11 @@
     </p>
     <aside class="issue" data-number="58"></aside>
     <p>
-      [=User agents=] MUST support the following [=digital credential/request
-      protocols=]:
+      [=User agents=] MUST support the following [=exchange protocols=]:
     </p>
     <table class="data">
       <caption>
-        Table of officially registered [=digital credential/request
-        protocols=].
+        Table of officially registered [=exchange protocols=].
       </caption>
       <thead>
         <tr>

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ protocols.
       </dt>
       <dd>
         A cryptographically secured digital document containing one or more
-        [=claims=] made by an [=issuer=] about a [=subject=]. Examples include
+        [=claims=] made by an [=issuer=] about one or more [=subjects=]. Examples include
         ISO mobile driver's licenses [[ISO18013-5]] and W3C [=verifiable
         credentials=] [[VC-DATA-MODEL-2.0]].
       </dd>
@@ -211,7 +211,7 @@ protocols.
     </h2>
     <p>
       The {{IdentityRequestProvider}} dictionary is used to specify an
-      [=exchange protocol=] and [=presentation request=], which the user agent
+      [=exchange protocol=] and a [=presentation request=], which the user agent
       MAY match against a [=credential provider=].
     </p>
     <pre class="idl">

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ the definitions are likely to change over the next several months.
         [=claims=] made by an [=issuer=] about one or more [=subjects=].
 
         <p class="note" title="Focus on digital credentials about people">
-          This specification is focused on digital credentials pertaining to
+          This specification is currently focused on digital credentials pertaining to
           people.
         </p>
       </dd>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ the definitions are likely to change over the next several months.
         <dfn data-dfn-for="digital credential">query</dfn>
       </dt>
       <dd>
-        A format that a [=verifier=] uses, via an [=digital credential/exchange
+        A format that [=verifier=] software or a [=user agent=] uses, via an [=digital credential/exchange
         protocol=], to request a [=digital credential=] from a [=holder=].
       </dd>
       <dt>

--- a/index.html
+++ b/index.html
@@ -89,9 +89,7 @@ the definitions are likely to change over the next several months.
       </dt>
       <dd>
         A cryptographically signed digital document containing one or more
-        [=claims=] made by an [=issuer=] about one or more [=subjects=]. Examples include
-        ISO mobile driver's licenses [[ISO18013-5]] and W3C [=verifiable
-        credentials=] [[VC-DATA-MODEL-2.0]].
+        [=claims=] made by an [=issuer=] about one or more [=subjects=].
       </dd>
       <dt>
         <dfn>Credential provider</dfn>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ protocols.
       <dd>
         Software that provides a user interface for querying, selecting, and
         establishing consent for the [=presentation=] of a [=digital
-        credential=]. Examples include a digital wallet, or a password manager,
+        credential=]. Examples include a digital wallet, or a login manager,
         that manages various
         <a href="#credential-type-examples">credential types</a>.
       </dd>

--- a/index.html
+++ b/index.html
@@ -97,27 +97,17 @@ the definitions are likely to change over the next several months.
         </p>
       </dd>
       <dt>
-        <dfn>Credential manager</dfn>
-      </dt>
-      <dd>
-        Software that provides a user interface for querying, selecting, and
-        establishing consent for the [=presentation=] of a [=digital
-        credential=]. Examples include a digital wallet, or a login manager,
-        that manages various [=example credential types|credential types=].
-      </dd>
-      <dt>
         <dfn data-dfn-for="digital credential">query</dfn>
       </dt>
       <dd>
         A format that a [=verifier=] uses, via an [=digital credential/exchange
-        protocol=], to request a [=digital credential=] from a [=credential
-        manager=].
+        protocol=], to request a [=digital credential=] from a [=holder=].
       </dd>
       <dt>
         <dfn>Presentation</dfn>
       </dt>
       <dd>
-        A format that a [=credential manager=] uses, via an [=digital
+        A format that a [=holder=] uses, via an [=digital
         credential/exchange protocol=], to respond to a [=digital
         credential/query=] by a [=verifier=].
       </dd>
@@ -126,7 +116,7 @@ the definitions are likely to change over the next several months.
       </dt>
       <dd>
         A protocol used for exchanging a [=digital credential=] between a
-        [=credential manager=] and a [=verifier=]. See section
+        [=holder=] and a [=verifier=]. See section
         [[[#protocol-registry]]].
       </dd>
     </dl>
@@ -191,17 +181,17 @@ the definitions are likely to change over the next several months.
     </h2>
     <pre class="idl">
     dictionary DigitalCredentialRequestOptions {
-      sequence&lt;IdentityRequestProvider&gt; managers;
+      sequence&lt;IdentityRequestProvider&gt; providers;
     };
     </pre>
     <h3>
-      The `managers` member
+      The `providers` member
     </h3>
     <p>
-      The <dfn data-dfn-for="DigitalCredentialRequestOptions">managers</dfn>
+      The <dfn data-dfn-for="DigitalCredentialRequestOptions">providers</dfn>
       specify an [=digital credential/exchange protocol=] and [=digital
-      credential/query=], which the user agent MAY match against a [=credential
-      manager=].
+      credential/query=], which the user agent MAY match against a
+      holder's software, such as a digital wallet.
     </p>
     <h2>
       The `IdentityRequestProvider` dictionary
@@ -209,7 +199,8 @@ the definitions are likely to change over the next several months.
     <p>
       The {{IdentityRequestProvider}} dictionary is used to specify an [=digital
       credential/exchange protocol=] and a [=digital credential/query=], which
-      the user agent MAY match against a [=credential manager=].
+      the user agent MAY match against software used by a holder, such as
+      a digital wallet.
     </p>
     <pre class="idl">
     dictionary IdentityRequestProvider {
@@ -235,8 +226,8 @@ the definitions are likely to change over the next several months.
     </h3>
     <p>
       The <dfn data-dfn-for="IdentityRequestProvider">request</dfn> member is
-      the request to be handled by the user's selected [=credential
-      manager=].
+      the request to be handled by the holder's software, such as a
+      digital wallet.
     </p>
     <h2>
       The `DigitalCredential` interface


### PR DESCRIPTION
This PR attempts to align the terminology used in the Data Model section with language that is compatible with multiple digital credential ecosystems.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msporny/digital-identities/pull/83.html" title="Last updated on Mar 6, 2024, 11:33 PM UTC (6859ed9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-identities/83/292a71a...msporny:6859ed9.html" title="Last updated on Mar 6, 2024, 11:33 PM UTC (6859ed9)">Diff</a>