### PR TITLE
chore: add tidy workflow

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -1,0 +1,20 @@
+name: Tidy document
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - gh-pages
+
+jobs:
+  tidy:
+    name: Tidy up
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install tidy-html5
+      - run: tidy -config tidyconfig.txt -o index.html index.html
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          title: "Tidied up document using tidy-html5"
+          commit-message: "chore: tidy up index.html"
+          branch: html-tidy

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: brew install tidy-html5
       - run: tidy -config tidyconfig.txt -o index.html index.html
-      - uses: peter-evans/create-pull-request@v3
+      - uses: peter-evans/create-pull-request@v6
         with:
           title: "Tidied up document using tidy-html5"
           commit-message: "chore: tidy up index.html"

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - gh-pages
+      - main
 
 jobs:
   tidy:


### PR DESCRIPTION
Runs HTML tidy after pull requests are made, so we don't need to bother contributors with installing tidy locally. 

Keeps our spec's markup organized, making it easier to contribute to. 