### PR TITLE
Change DigitalCredential.data's type to 'any'

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
     <aside class="issue" title="Why the 'any' data type?">
       <p>
         We are currently exploring the use of a more structured data type for
-        the `data` member as we attempt to understand the requirements of
+        the `data` attribute as we attempt to understand the requirements of
         various digital credential formats and protocols. <strong>We expect
         this data type to change in the very near future.</strong>
       </p>

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
     [Exposed=Window, SecureContext]
     interface DigitalCredential : Credential {
       readonly attribute DOMString protocol;
-      [SameObject] readonly attribute Uint8Array data;
+      readonly attribute any data;
     };
     </pre>
     <h3>
@@ -251,9 +251,22 @@
     <h3>
       The `data` member
     </h3>
+    <aside class="issue" title="Why the 'any' data type?">
+      <p>
+        We are currently exploring the use of a more structured data type for
+        the `data` member as we attempt to understand the requirements of
+        various digital credential formats and protocols. <strong>We expect
+        this data type to change in the very near future.</strong>
+      </p>
+      <p>
+        We are also investigating how [[[webauthn]]] deals with this. See
+        <a href="https://github.com/WICG/digital-identities/issues/95">issue
+        #95</a>.
+      </p>
+    </aside>
     <p>
       The <dfn data-dfn-for="DigitalCredential">data</dfn> member is the
-      credential's encrypted data.
+      credential's response data.
     </p>
     <h2 id="protocol-registry">
       Registry of protocols for requesting digital credential


### PR DESCRIPTION
As we don't yet fully have consensus on the what structure we should use for the response's `.data`, @samuelgoto and I discussed switching it temporarily to `any`. 

That allows both WebKit (uses `Uint8Array`) and Chromium (uses `USVString`) to remain conformant while we work out the details (as per #95, for instance).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/digital-identities/pull/107.html" title="Last updated on Apr 26, 2024, 4:48 AM UTC (aee34a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/digital-identities/107/9fe77d3...aee34a1.html" title="Last updated on Apr 26, 2024, 4:48 AM UTC (aee34a1)">Diff</a>